### PR TITLE
Bram/universal build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,44 +1,43 @@
 cmake_minimum_required(VERSION 3.3)
+
 project(wpeframework-ocdm-playready-nexus-svp)
+
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(GNUInstallDirs)
 
-set(PLAYREADY_PKG_CONFIG_NAME "playready4" CACHE STRING "Playready pkg-config file name (default: playready4)")
-set(NAMESPACE "WPEFramework" CACHE STRING "Namespace of the project (default: WPEFramework)")
+# Thunder or WPEFramework will provide the proper NAMESPACE.
+find_package(Thunder QUIET)
+if(NOT Thunder_FOUND)
+    message(DEPRECATION "Thunder not found, swiching to WPEFramework")
+    find_package(WPEFramework REQUIRED)
+endif()
+
+find_package(PkgConfig REQUIRED)
+pkg_search_module(PLAYREADY4 playready4 QUIET)
+
+if(PLAYREADY4_FOUND)
+  find_package(Playready4 REQUIRED)
+else()
+  find_package(Playready3 REQUIRED)
+endif()
 
 set(DRM_PLUGIN_NAME PlayReady)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-find_package(PkgConfig REQUIRED)
-pkg_search_module(PLAYREADY ${PLAYREADY_PKG_CONFIG_NAME})
-
-message(STATUS "PLAYREADY_CFLAGS_OTHER: ${PLAYREADY_CFLAGS_OTHER}")
-
-set(DRM_PLUGIN_SOURCES
-  MediaSession.cpp
-  MediaSystem.cpp
-  MediaSession.h)
-
-set(DRM_PLUGIN_INCLUDE_DIRS
-  ${PLAYREADY_INCLUDE_DIRS}
-  ${DRM_PLUGIN_INCLUDE_DIRS}
+add_library(${DRM_PLUGIN_NAME} SHARED 
+    MediaSession.cpp
+    MediaSystem.cpp
 )
 
-set(DRM_PLUGIN_CFLAGS_OTHER
-  ${PLAYREADY_CFLAGS_OTHER}
-  ${DRM_PLUGIN_CFLAGS_OTHER}
+set_target_properties(${DRM_PLUGIN_NAME} PROPERTIES 
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED YES
+    SUFFIX ".drm"
+    PREFIX ""
 )
 
-set(DRM_PLUGIN_LIBRARIES
-  ${PLAYREADY_LIBRARIES}
+target_link_libraries(${DRM_PLUGIN_NAME} 
+    PRIVATE
+        Playready::Playready
 )
-
-add_library(${DRM_PLUGIN_NAME} SHARED ${DRM_PLUGIN_SOURCES})
-target_compile_definitions(${DRM_PLUGIN_NAME} PRIVATE ${DRM_PLUGIN_CFLAGS_OTHER})
-target_include_directories(${DRM_PLUGIN_NAME} PRIVATE ${DRM_PLUGIN_INCLUDE_DIRS})
-target_link_libraries(${DRM_PLUGIN_NAME} ${DRM_PLUGIN_LIBRARIES})
-set_target_properties(${DRM_PLUGIN_NAME} PROPERTIES SUFFIX ".drm")
-set_target_properties(${DRM_PLUGIN_NAME} PROPERTIES PREFIX "")
 
 install(TARGETS ${DRM_PLUGIN_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/${NAMESPACE}/OCDM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ else()
   find_package(Playready3 REQUIRED)
 endif()
 
+if(NOT TARGET Playready::Playready)
+  message(FATAL_ERROR "Playready library not found.")
+endif()
+
 set(DRM_PLUGIN_NAME PlayReady)
 
 add_library(${DRM_PLUGIN_NAME} SHARED 

--- a/cmake/FindPlayready3.cmake
+++ b/cmake/FindPlayready3.cmake
@@ -1,0 +1,89 @@
+# - Try to find Broadcom Nexus Playready 3.
+# Once done this will define
+#  PlayreadyFOUND     - System has a Nexus Playready 3 
+#  Playready::Playready - The Nexus Playready 3 library
+#
+# Copyright (C) 2019 Metrological B.V
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+find_package(NEXUS REQUIRED)	
+find_package(NXCLIENT REQUIRED)
+
+find_path(PLAYREADY_INCLUDE_DIR drmmanager.h
+    PATH_SUFFIXES playready refsw)
+
+find_path(NEXUS_INCLUDE_DIR b_secbuf.h
+    PATH_SUFFIXES refsw)
+
+list(APPEND PLAYREADY_INCLUDE_DIRS ${PLAYREADY_INCLUDE_DIR} ${NEXUS_INCLUDE_DIR})
+
+# main lib
+find_library(PLAYREADY_LIBRARY playready30pk)
+
+# needed libs
+list(APPEND NeededLibs prdyhttp)
+
+# needed svp libs
+list(APPEND NeededLibs drmrootfs srai b_secbuf)
+
+foreach (_library ${NeededLibs})
+    find_library(LIBRARY_${_library} ${_library})
+    if(NOT EXISTS "${LIBRARY_${_library}}")
+        message(SEND_ERROR "Could not find mandatory library: ${_library}")
+    endif()
+    list(APPEND PLAYREADY_LIBRARIES ${LIBRARY_${_library}})
+endforeach ()
+
+set(PLAYREADY_COMPILE_DEFINITIONS
+    BSTD_CPU_ENDIAN=BSTD_ENDIAN_LITTLE
+    USE_PK_NAMESPACES=1
+    DRM_INCLUDE_PK_NAMESPACE_USING_STATEMENT=1
+    DRM_BUILD_PROFILE=900
+    CMD_DRM_PLAYREADY_SAGE_IMPL
+    PLAYREADY_SAGE
+)
+
+if(EXISTS "${PLAYREADY_LIBRARY}")
+    set(PLAYREADY_FOUND TRUE)
+
+    if(NOT TARGET Playready::Playready)
+        add_library(Playready::Playready UNKNOWN IMPORTED)
+        
+        set_target_properties(Playready::Playready PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES   "CXX"
+            IMPORTED_LOCATION                   "${PLAYREADY_LIBRARY}"
+            IMPORTED_NO_SONAME                  TRUE
+            INTERFACE_INCLUDE_DIRECTORIES       "${PLAYREADY_INCLUDE_DIRS}"
+            INTERFACE_COMPILE_DEFINITIONS       "${PLAYREADY_COMPILE_DEFINITIONS}"
+            INTERFACE_LINK_LIBRARIES            "${PLAYREADY_LIBRARIES}" NEXUS::NEXUS NXCLIENT::NXCLIENT
+        )
+
+        mark_as_advanced(
+            PLAYREADY_LIBRARY 
+            PLAYREADY_COMPILE_DEFINITIONS 
+            PLAYREADY_LIBRARIES 
+            PLAYREADY_COMPILE_DEFINITIONS 
+            PLAYREADY_INCLUDE_DIR 
+            NEXUS_INCLUDE_DIR
+        )
+    endif()
+endif()

--- a/cmake/FindPlayready3.cmake
+++ b/cmake/FindPlayready3.cmake
@@ -63,7 +63,7 @@ set(PLAYREADY_COMPILE_DEFINITIONS
 )
 
 if(EXISTS "${PLAYREADY_LIBRARY}")
-    set(PLAYREADY_FOUND TRUE)
+    set(Playready_FOUND TRUE)
 
     if(NOT TARGET Playready::Playready)
         add_library(Playready::Playready UNKNOWN IMPORTED)

--- a/cmake/FindPlayready4.cmake
+++ b/cmake/FindPlayready4.cmake
@@ -1,0 +1,60 @@
+# - Try to find Playready 4.
+# Once done this will define
+#  Playready_FOUND     - System has a Playready 4
+#  Playready::Playready - The Playready 4 library
+#
+# Copyright (C) 2019 Metrological B.V
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+find_package(PkgConfig REQUIRED)
+include(FindPackageHandleStandardArgs
+
+pkg_search_module(PC_PLAYREADY4 playready4 REQUIRED)
+
+find_package_handle_standard_args(PC_PLAYREADY4 DEFAULT_MSG 
+    PC_PLAYREADY4_INCLUDE_DIRS 
+    PC_PLAYREADY4_LIBRARIES 
+    PC_PLAYREADY4_CFLAGS_OTHER)
+    
+mark_as_advanced(
+    PC_PLAYREADY4_INCLUDE_DIRS 
+    PC_PLAYREADY4_LIBRARIES  
+    PC_PLAYREADY4_CFLAGS_OTHER
+)
+
+if(PC_PLAYREADY4_FOUND)
+    list(GET ${PC_PLAYREADY4_LIBRARIES} 0 PLAYREADY4_LIBRARY)
+
+    if(NOT TARGET Playready::Playready)
+        add_library(Playready::Playready UNKNOWN IMPORTED)
+        
+        set_target_properties(Playready::Playready PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES   "CXX"
+            IMPORTED_LOCATION                   "${PLAYREADY4_LIBRARY}"
+            IMPORTED_NO_SONAME                  TRUE
+            INTERFACE_INCLUDE_DIRECTORIES       "${PC_PLAYREADY4_INCLUDE_DIRS}"
+            INTERFACE_LINK_LIBRARIES            "${PC_PLAYREADY4_LIBRARIES}"
+            INTERFACE_COMPILE_OPTIONS           "${PC_PLAYREADY4_CFLAGS_OTHER}"
+        )
+    endif()
+endif()

--- a/cmake/FindPlayready4.cmake
+++ b/cmake/FindPlayready4.cmake
@@ -27,7 +27,7 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 find_package(PkgConfig REQUIRED)
-include(FindPackageHandleStandardArgs
+include(FindPackageHandleStandardArgs)
 
 pkg_search_module(PC_PLAYREADY4 playready4 REQUIRED)
 

--- a/cmake/FindPlayready4.cmake
+++ b/cmake/FindPlayready4.cmake
@@ -43,6 +43,8 @@ mark_as_advanced(
 )
 
 if(PC_PLAYREADY4_FOUND)
+    set(Playready_FOUND TRUE)
+    
     list(GET ${PC_PLAYREADY4_LIBRARIES} 0 PLAYREADY4_LIBRARY)
 
     if(NOT TARGET Playready::Playready)


### PR DESCRIPTION
Let's support both Playready 3 and 4 without the use of configure time variables. Now both versions have their own context and will configure the target Playready::Playready according the their specific requirements. The top level cmake should only contain generic requirements like linking to a Playready.  If something needs to be fixed for a specific version of Playready then add the fix in one of targets in the Playready specific files.

It has the same approach as plugins, so i guess this will work for both Yocto and Buildroot or any other build system that supports cmake