### PR TITLE
Odeveci/unified context initialize

### DIFF
--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -670,12 +670,7 @@ ErrorExit:
         
         m_eKeyState = KEY_ERROR;
         if (m_piCallback) {
-            for (uint8_t  i = 0; i < oLicenseResponse.m_cAcks; ++i) {
-                // Make MS endianness to Cenc endianness.
-                ToggleKeyIdFormat(DRM_ID_SIZE, oLicenseResponse.m_rgoAcks[i].m_oKID.rgb);
-
-                m_piCallback->OnKeyStatusUpdate("KeyError", oLicenseResponse.m_rgoAcks[i].m_oKID.rgb, DRM_ID_SIZE);
-            }
+            m_piCallback->OnError(0, CDMi_S_FALSE, "KeyError");
             m_piCallback->OnKeyStatusesUpdated();
         }
     }

--- a/MediaSession.h
+++ b/MediaSession.h
@@ -102,8 +102,7 @@ public:
     MediaKeySession(
         const uint8_t *f_pbInitData, uint32_t f_cbInitData, 
         const uint8_t *f_pbCDMData, uint32_t f_cbCDMData, 
-        DRM_VOID *f_pOEMContext, DRM_APP_CONTEXT * poAppContext,  
-        bool initiateChallengeGeneration = false);
+        DRM_VOID *f_pOEMContext, DRM_APP_CONTEXT * poAppContext);
    
     ~MediaKeySession();
     bool playreadyGenerateKeyRequest();
@@ -209,7 +208,6 @@ private:
     DRM_ID mBatchId;
 
     bool m_decryptInited;
-    bool mInitiateChallengeGeneration;
 
     DecryptContextMap mDecryptContextMap;
 };

--- a/MediaSystem.cpp
+++ b/MediaSystem.cpp
@@ -209,13 +209,11 @@ public:
         const uint8_t *f_pbInitData, uint32_t f_cbInitData, 
         const uint8_t *f_pbCDMData, uint32_t f_cbCDMData, 
         IMediaKeySession **f_ppiMediaKeySession) {
-        bool isNetflixPlayready = (strstr(keySystem.c_str(), "netflix") != nullptr);
 
         *f_ppiMediaKeySession = new CDMi::MediaKeySession(
             f_pbInitData, f_cbInitData, 
             f_pbCDMData, f_cbCDMData, 
-            m_drmOemContext, m_poAppContext.get(),
-            !isNetflixPlayready
+            m_drmOemContext, m_poAppContext.get()
             );
 
         return CDMi_SUCCESS; 


### PR DESCRIPTION
Lets keep this PR active once you validated on your side, we can merge with master. 

@Bram, it seems keyupdatecallback can not handle KeyError message, and also license response can be empty in case of failure which causes crash. The better seems to me onError which we can handle on application level. Is it also ok for NF? 